### PR TITLE
Added type aliases + more restrictive typing around JSON

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7282,6 +7282,12 @@
       "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
       "dev": true
     },
+    "json-typescript": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/json-typescript/-/json-typescript-1.1.2.tgz",
+      "integrity": "sha512-Np07MUsYMKbB0nNlw/MMIRjUK7ehO48LA4FsrzrhCfTUxMKbvOBAo0sc0b4nQ80ge9d32sModCunCgoyUojgUA==",
+      "dev": true
+    },
     "json5": {
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",

--- a/package.json
+++ b/package.json
@@ -95,6 +95,7 @@
     "husky": "^1.0.1",
     "jest": "^23.6.0",
     "jest-config": "^23.6.0",
+    "json-typescript": "^1.1.2",
     "lint-staged": "^8.0.0",
     "lodash.camelcase": "^4.3.0",
     "prettier": "^1.14.3",

--- a/src/fission.ts
+++ b/src/fission.ts
@@ -1,6 +1,11 @@
 import axios from 'axios'
+import { Value as JSONValue } from 'json-typescript'
 
 const BASE_URL_DEFAULT = "https://hostless.dev"
+
+export type Content = JSONValue
+export type Upload = JSONValue | File
+export type CID = string
 
 export default class Fission {
   baseURL: string
@@ -18,42 +23,42 @@ export default class Fission {
     return this
   }
 
-  async list(): Promise<string[]> {
+  async list(): Promise<CID[]> {
     if(!this.auth){
       throw new Error("Must be logged in to list available CIDs")
     }
-    const { data } = await axios.get<string[]>(`${this.baseURL}/ipfs/cids`, { auth: this.auth })
+    const { data } = await axios.get<CID[]>(`${this.baseURL}/ipfs/cids`, { auth: this.auth })
     return data
   }
 
-  async content(cid: string): Promise<string | object> {
+  async content(cid: CID): Promise<Content> {
     const headers = { 'content-type': 'application/octet-stream' }
-    const { data } = await axios.get<string | object>(`${this.baseURL}/ipfs/${cid}`, { headers })
+    const { data } = await axios.get<Content>(`${this.baseURL}/ipfs/${cid}`, { headers })
     return data
   }
 
-  url(cid: string): string {
+  url(cid: CID): string {
     return `${this.baseURL}/ipfs/${cid}`
   }
 
-  async add(content: string | Object | File, name?: string): Promise<string> {
+  async add(content: Content, name?: string): Promise<CID> {
     if(!this.auth){
       throw new Error("Must be logged in to add content to IPFS")
     }
     const headers = { 'content-type': 'application/octet-stream' }
     const nameStr = name ? `?name=${name}` : ''
-    const { data } = await axios.post<string>(`${this.baseURL}/ipfs${nameStr}`, content, { headers, auth: this.auth })
+    const { data } = await axios.post<CID>(`${this.baseURL}/ipfs${nameStr}`, content, { headers, auth: this.auth })
     return data
   }
 
-  async remove(cid: string) {
+  async remove(cid: CID) {
     if(!this.auth){
       throw new Error("Must be logged in to remove content from IPFs")
     }
     await axios.delete(`${this.baseURL}/ipfs/${cid}`, { auth: this.auth })
   }
 
-  async pin(cid: string) {
+  async pin(cid: CID) {
     if(!this.auth){
       throw new Error("Must be logged in to pin content")
     }


### PR DESCRIPTION
# Problem
---
Code could be more readable using type aliases. Types around JSON were too permissive. 

#Solution
---
Added type aliases for (CID, Content, Upload). Changed types of `Content` + `Upload` to `JSONValue` which are much more descriptive than the very permissive type `Object`