### PR TITLE
Added FissionUser subclass for library methods that require auth

### DIFF
--- a/src/fission.ts
+++ b/src/fission.ts
@@ -9,26 +9,13 @@ export type CID = string
 
 export default class Fission {
   baseURL: string
-  auth?: { username: string; password: string }
 
   constructor(baseURL?: string) {
     this.baseURL = baseURL || BASE_URL_DEFAULT
   }
 
-  login(username: string, password: string): Fission {
-    if (!username || !password) {
-      throw new Error('Must supply both a username and password on login')
-    }
-    this.auth = { username, password }
-    return this
-  }
-
-  async list(): Promise<CID[]> {
-    if (!this.auth) {
-      throw new Error('Must be logged in to list available CIDs')
-    }
-    const { data } = await axios.get<CID[]>(`${this.baseURL}/ipfs/cids`, { auth: this.auth })
-    return data
+  login(username: string, password: string): FissionUser {
+    return new FissionUser(this.baseURL, username, password)
   }
 
   async content(cid: CID): Promise<Content> {
@@ -40,11 +27,29 @@ export default class Fission {
   url(cid: CID): string {
     return `${this.baseURL}/ipfs/${cid}`
   }
+}
+
+export class FissionUser extends Fission {
+  auth: {
+    username: string
+    password: string
+  }
+
+  constructor(baseURL: string, username: string, password: string) {
+    if (!username || !password) {
+      throw new Error('Must supply both a username and password on login')
+    }
+    super(baseURL)
+    this.auth = { username, password }
+    return this
+  }
+
+  async list(): Promise<CID[]> {
+    const { data } = await axios.get<CID[]>(`${this.baseURL}/ipfs/cids`, { auth: this.auth })
+    return data
+  }
 
   async add(content: Content, name?: string): Promise<CID> {
-    if (!this.auth) {
-      throw new Error('Must be logged in to add content to IPFS')
-    }
     const headers = { 'content-type': 'application/octet-stream' }
     const nameStr = name ? `?name=${name}` : ''
     const { data } = await axios.post<CID>(`${this.baseURL}/ipfs${nameStr}`, content, {
@@ -55,16 +60,10 @@ export default class Fission {
   }
 
   async remove(cid: CID) {
-    if (!this.auth) {
-      throw new Error('Must be logged in to remove content from IPFs')
-    }
     await axios.delete(`${this.baseURL}/ipfs/${cid}`, { auth: this.auth })
   }
 
   async pin(cid: CID) {
-    if (!this.auth) {
-      throw new Error('Must be logged in to pin content')
-    }
     await axios.put(`${this.baseURL}/ipfs/${cid}`, {}, { auth: this.auth })
   }
 }

--- a/test/fission.test.ts
+++ b/test/fission.test.ts
@@ -1,4 +1,4 @@
-import Fission from '../src/fission'
+import Fission, { FissionUser } from '../src/fission'
 
 const baseURL = process.env.INTERPLANETARY_FISSION_URL
 const username = process.env.INTERPLANETARY_FISSION_USERNAME || ''
@@ -11,7 +11,7 @@ const randomString = () => {
 }
 
 describe('Fission', () => {
-  let fission: Fission
+  let fission: FissionUser
 
   beforeEach(() => {
     fission = new Fission(baseURL).login(username, password)


### PR DESCRIPTION
# Problem
Many of the methods on the Fission class require user auth and will throw an error if called without being authenticated first. There's a difference in the use of these methods that isn't reflected in the structure of the code.

# Solution
Split the `Fission` class into `Fission` (with methods that don't require auth) and `FissionUser` (with methods that do require auth). `Fission.login(username, password)` returns an instance of `FissionUser`. As a result we can remove all of the `throw` statements from methods that require auth since an instance of `FissionUser` is guaranteed to be logged in.