### PR TITLE
Rewrote tests for more coverage + one assertion per test

### DIFF
--- a/src/fission.ts
+++ b/src/fission.ts
@@ -36,9 +36,6 @@ export class FissionUser extends Fission {
   }
 
   constructor(baseURL: string, username: string, password: string) {
-    if (!username || !password) {
-      throw new Error('Must supply both a username and password on login')
-    }
     super(baseURL)
     this.auth = { username, password }
     return this


### PR DESCRIPTION
# Problem
The test suite had partial coverage of the code and tests contained more than one assertion each. 

# Solution
Added additional tests so that the code has 100% coverage. Rewrote existing tests such that each test has only one assertion and related tests are grouped in `describe` blocks.