### PR TITLE
Increases Axios file transfer limit

### DIFF
--- a/src/api/ipfs.ts
+++ b/src/api/ipfs.ts
@@ -1,7 +1,7 @@
 /* TYPES */
 import axios from 'axios'
-import { BASE_URL_DEFAULT } from '../constants'
-import { Auth, Content, CID, Peer } from '../types'
+import { BASE_URL_DEFAULT, MAX_CONTENT_LENGTH } from '../constants'
+import { Auth, Content, CID, Peer, ByteLength } from '../types'
 
 export const content = async (cid: CID, baseURL = BASE_URL_DEFAULT): Promise<Content> => {
   const headers = { 'content-type': 'application/octet-stream' }
@@ -22,10 +22,13 @@ export const add = async (
 ): Promise<CID> => {
   const headers = { 'content-type': 'application/octet-stream' }
   const nameStr = name ? `?name=${name}` : ''
-  const { data } = await axios.post<CID>(`${baseURL}/ipfs${nameStr}`, content, {
+  const maxContentLength: ByteLength = MAX_CONTENT_LENGTH
+  const axiosOptions = {
     headers,
+    maxContentLength,
     auth
-  })
+  }
+  const { data } = await axios.post<CID>(`${baseURL}/ipfs${nameStr}`, content, axiosOptions)
   return data
 }
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,1 +1,2 @@
 export const BASE_URL_DEFAULT = 'https://runfission.com'
+export const MAX_CONTENT_LENGTH = 100_000_000

--- a/src/types.ts
+++ b/src/types.ts
@@ -4,6 +4,7 @@ export type Content = JSONValue
 export type Upload = JSONValue | File
 export type CID = string
 export type Peer = string
+export type ByteLength = number
 
 export type Auth = {
   username: string

--- a/test/client.test.ts
+++ b/test/client.test.ts
@@ -1,7 +1,7 @@
 import { Object as JSONObject } from 'json-typescript'
 
 import Fission, { FissionUser, getContentURL, Auth } from '../src'
-import { BASE_URL_DEFAULT } from '../src/constants'
+import { BASE_URL_DEFAULT, MAX_CONTENT_LENGTH } from '../src/constants'
 import { describeRequest } from './util'
 
 // NOTE: We must import sinon in this manner: https://github.com/sinonjs/sinon/issues/1711
@@ -154,6 +154,7 @@ describe('FissionUser', () => {
         headers: {
           'content-type': 'application/octet-stream'
         },
+        maxContentLength: MAX_CONTENT_LENGTH,
         auth: TEST_AUTH
       }
     ]
@@ -172,6 +173,7 @@ describe('FissionUser', () => {
         headers: {
           'content-type': 'application/octet-stream'
         },
+        maxContentLength: MAX_CONTENT_LENGTH,
         auth: TEST_AUTH
       }
     ]


### PR DESCRIPTION
Resolves #23 

This PR Includes:
* Increased file transfer limit to 100MB
* Custom error including:
  - Relevant message
  - file size in bytes
  - maximum file size in bytes
  - detailed human readable explanation of the problem and possible solutions

Pending:
* Agreement on new file transfer limit
* Refactor to handle conditional logic within the FissionErrors file.

Future Considerations:
* User specific transfer limits