### PR TITLE
Validating Base URLs in Fission and FissionUser

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -10,7 +10,7 @@ import {
   resetPassword,
   verify
 } from './api'
-import { getContentURL } from './util'
+import { getContentURL, validateBaseURL } from './util'
 import { Content, CID, Auth } from './types'
 import { BASE_URL_DEFAULT } from './constants'
 
@@ -23,7 +23,7 @@ export class Fission {
   baseURL: string
 
   constructor(baseURL?: string) {
-    this.baseURL = baseURL || BASE_URL_DEFAULT
+    this.baseURL = baseURL ? validateBaseURL(baseURL) : BASE_URL_DEFAULT
   }
 
   login(username: string, password: string): FissionUser {

--- a/src/client.ts
+++ b/src/client.ts
@@ -10,7 +10,7 @@ import {
   resetPassword,
   verify
 } from './api'
-import { getContentURL, validateBaseURL } from './util'
+import { getContentURL, trimBaseURL } from './util'
 import { Content, CID, Auth } from './types'
 import { BASE_URL_DEFAULT } from './constants'
 
@@ -23,7 +23,7 @@ export class Fission {
   baseURL: string
 
   constructor(baseURL?: string) {
-    this.baseURL = baseURL ? validateBaseURL(baseURL) : BASE_URL_DEFAULT
+    this.baseURL = baseURL ? trimBaseURL(baseURL) : BASE_URL_DEFAULT
   }
 
   login(username: string, password: string): FissionUser {

--- a/src/util.ts
+++ b/src/util.ts
@@ -4,3 +4,15 @@ import { CID } from './types'
 export const getContentURL = (cid: CID, baseURL = BASE_URL_DEFAULT): string => {
   return `${baseURL}/ipfs/${cid}`
 }
+
+// Slightly modified from https://www.regextester.com/94502
+const BASE_URL_PATTERN = /^(?:http(s)?:\/\/)[\w.-]+(?:\.[\w\.-]+)+[\w\-\._~:/[\]@!\$&'\(\)\*\+,;=.]+[^/]$/
+
+export const validateBaseURL = (baseURL: string): string => {
+  if (baseURL.match(BASE_URL_PATTERN) === null) {
+    throw Error(
+      `Bad BaseURL (${baseURL}) provided. Base URL should be a full web URL with no trailing slash or query parameters.`
+    )
+  }
+  return baseURL
+}

--- a/src/util.ts
+++ b/src/util.ts
@@ -5,14 +5,6 @@ export const getContentURL = (cid: CID, baseURL = BASE_URL_DEFAULT): string => {
   return `${baseURL}/ipfs/${cid}`
 }
 
-// Slightly modified from https://www.regextester.com/94502
-const BASE_URL_PATTERN = /^(?:http(s)?:\/\/)[\w.-]+(?:\.[\w\.-]+)+[\w\-\._~:/[\]@!\$&'\(\)\*\+,;=.]+[^/]$/
-
-export const validateBaseURL = (baseURL: string): string => {
-  if (baseURL.match(BASE_URL_PATTERN) === null) {
-    throw Error(
-      `Bad BaseURL (${baseURL}) provided. Base URL should be a full web URL with no trailing slash or query parameters.`
-    )
-  }
-  return baseURL
+export const trimBaseURL = (baseUrl: string): string => {
+  return baseUrl.endsWith('/') ? baseUrl.slice(0, -1) : baseUrl
 }

--- a/test/client.test.ts
+++ b/test/client.test.ts
@@ -62,6 +62,16 @@ describe('Fission', () => {
     expect(fissionDefault.baseURL).toEqual(BASE_URL_DEFAULT)
   })
 
+  test.each([
+    ['trailing slash', 'https://example.com/'],
+    ['missing protocol', 'example.com'],
+    ['root path', '/path/from/localhost'],
+    ['query params', 'https://example.com?param=true'],
+    ['malformed', 'https://badexample.c']
+  ])('throws error when base URL has problem: %s', (desc, path) => {
+    expect(() => new Fission(path)).toThrowError()
+  })
+
   describeRequest({
     desc: 'Register User',
     method: 'post',

--- a/test/client.test.ts
+++ b/test/client.test.ts
@@ -62,14 +62,9 @@ describe('Fission', () => {
     expect(fissionDefault.baseURL).toEqual(BASE_URL_DEFAULT)
   })
 
-  test.each([
-    ['trailing slash', 'https://example.com/'],
-    ['missing protocol', 'example.com'],
-    ['root path', '/path/from/localhost'],
-    ['query params', 'https://example.com?param=true'],
-    ['malformed', 'https://badexample.c']
-  ])('throws error when base URL has problem: %s', (desc, path) => {
-    expect(() => new Fission(path)).toThrowError()
+  it("removes trailing slashes on provided BASE_URL", () => {
+    const trailingFission = new Fission("https://example.com/")
+    expect(trailingFission.baseURL).toEqual("https://example.com")
   })
 
   describeRequest({


### PR DESCRIPTION
## Summary
The issue was raised that bad base URLS could be injected into the application.

There are still outstanding questions. Do we want to validate Base URLs everywhere, do we want to throw errors or log to console, etc etc. This is just one approach.

## Test plan (required)

Tests were added around this functionality, with a series of rejected base URLs.

## Closing issues
closes #25 

## Before Merge
* [x] Ensure you've rebuilt the docs with `npm run build:docs`

## After Merge
* [ ] Does this change invalidate any docs or tutorials? _If so ensure the changes needed are either made or recorded_
* [ ] Does this change require a release to be made? Is so please create and deploy the release
* [ ]
